### PR TITLE
Fix API to save new relation.

### DIFF
--- a/lib/src/service/entity_relation_service.dart
+++ b/lib/src/service/entity_relation_service.dart
@@ -13,12 +13,11 @@ class EntityRelationService {
 
   EntityRelationService._internal(this._tbClient);
 
-  Future<EntityRelation> saveRelation(EntityRelation relation,
+  Future<void> saveRelation(EntityRelation relation,
       {RequestConfig? requestConfig}) async {
-    var response = await _tbClient.post<Map<String, dynamic>>('/api/relation',
+    await _tbClient.post('/api/relation',
         data: jsonEncode(relation),
         options: defaultHttpOptionsFromConfig(requestConfig));
-    return EntityRelation.fromJson(response.data!);
   }
 
   Future<void> deleteRelation(EntityId fromId, String relationType,


### PR DESCRIPTION
Without this PR calling of `saveRelation` throws the error:
```
Error: ThingsboardError: message: [type 'String' is not a subtype of type 'Map<String, dynamic>' in type cast], errorCode: 2, status: null
#0      toThingsboardError (package:thingsboard_client/src/error/_thingsboard_error_handler_io.dart:86:18)
#1      ThingsboardClient.post (package:thingsboard_client/src/thingsboard_client_base.dart:211:13)
<asynchronous suspension>
#2      EntityRelationService.saveRelation (package:thingsboard_client/src/service/entity_relation_service.dart:18:20)
<asynchronous suspension>
```