### PR TITLE
Fix problem with websocket and loosing internet

### DIFF
--- a/lib/src/service/telemetry_websocket_service.dart
+++ b/lib/src/service/telemetry_websocket_service.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:web_socket_channel/status.dart' as status;
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../model/model.dart';
 import '../thingsboard_client_base.dart';
@@ -210,6 +210,7 @@ class TelemetryWebsocketService implements TelemetryService {
       }, onError: (e) {
         _onError(e);
       });
+      channel.ready.onError((error, stackTrace) => _onError(error));
       _onOpen();
     } catch (e) {
       _onClose();


### PR DESCRIPTION
As described in the issue: #13, the app crashes when we are using the websocket and we loose internet.

A fix recommendation was given in the source lib, but it forces to have asynchronous method. But here, all the methods are synchronous (which is not great).

The ideal way will be to change all the method from synchronous to asynchronous, but I think that will change a lot of things.

Therefore, I simply redirect the `onError` returns from the future to the `_onError` callback