### PR TITLE
fixing invalid JSON formatting 

### DIFF
--- a/lib/src/model/telemetry_models.dart
+++ b/lib/src/model/telemetry_models.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -363,7 +364,7 @@ abstract class RestJsonConverter {
             errorCode: ThingsBoardErrorCode.invalidArguments);
       }
     } else {
-      return JsonDataEntry(key, value.toString());
+      return JsonDataEntry(key, jsonEncode(value));
     }
   }
 


### PR DESCRIPTION
have changed the way we treat json values in **_parseValue** method, from now on json values will not be converted into map and then later into string which then results of json values losing the quotes.  this is **crucial** because it makes you work with correct JSON values instead of invalid ones. 

from this:
```
{ 
people: [
    {
      name: Alice,
      age: 30,
      hobbies: [reading, photography]
    },
    {
      name: Charlie,
      age: 35,
      hobbies: [painting, gardening]
    }
  ]
}
```
to this: 
```
  {
  "people": [
    {
      "name": "Alice",
      "age": 30,
      "hobbies": ["reading", "photography"]
    },
    {
      "name": "Charlie",
      "age": 35,
      "hobbies": ["painting", "gardening"]
    }
  ]
}
```