### PR TITLE
Don't include null timeseries data entries.

### DIFF
--- a/lib/src/model/telemetry_models.dart
+++ b/lib/src/model/telemetry_models.dart
@@ -338,7 +338,7 @@ abstract class RestJsonConverter {
       var result = <TsKvEntry>[];
       timeseries.forEach((key, value) {
         var values = value as List<dynamic>;
-        result.addAll(values.map((ts) {
+        result.addAll(values.where((ts) => ts[VALUE] != null).map((ts) {
           var entry = _parseValue(key, ts[VALUE]);
           return BasicTsKvEntry(ts[TS] as int, entry);
         }));


### PR DESCRIPTION
Apparently the server can send data that has the timestamp of now and a data value of null, if there isn't any datapoint available. This prevents a crash from trying to create a BasicTsKvEntry with a null value.