### PR TITLE
fix: parse AlarmComment.comment into AlarmCommentJsonNode on deserialization

### DIFF
--- a/lib/src/model/alarm_models.dart
+++ b/lib/src/model/alarm_models.dart
@@ -289,7 +289,7 @@ class AlarmComment {
   AlarmComment(this.id, this.createdTime, this.alarmId, this.userId, this.type,
       this.comment, this.name);
   AlarmComment.fromJson(Map<String, dynamic> json)
-      : comment = json['comment'],
+      : comment = _parseComment(json['comment']),
         id = json['id']['id'],
         createdTime = json['createdTime'],
         alarmId = AlarmId.fromJson(json['alarmId']),
@@ -304,9 +304,29 @@ class AlarmComment {
       "alarmId": alarmId.toJson(),
       "userId": userId?.toJson(),
       "type": type.toShortString(),
-      "comment": comment,
+      "comment": comment is AlarmCommentJsonNode
+          ? (comment as AlarmCommentJsonNode).toJson()
+          : comment,
       "name": name,
     };
+  }
+
+  static dynamic _parseComment(dynamic comment) {
+    if (comment is Map) {
+      return AlarmCommentJsonNode.fromJson(
+        Map<String, dynamic>.from(comment),
+      );
+    } else if (comment is String) {
+      return AlarmCommentJsonNode(
+        text: comment,
+        subtype: null,
+        userId: null,
+        edited: false,
+        editedOn: null,
+        assigneeId: null,
+      );
+    }
+    return comment;
   }
 }
 


### PR DESCRIPTION
## Summary

`AlarmComment.fromJson` now automatically parses the `dynamic comment` field into a typed `AlarmCommentJsonNode`, handling both `Map` (normal) and `String` (legacy mobile-posted) formats. `AlarmComment.toJson` properly serializes it back for the API.

## Root cause

The mobile app was posting comments as raw strings instead of `{"text": "..."}` objects. The server stores whatever it receives, so on read the `comment` field could be either a `Map` or a `String`. Since `comment` is typed as `dynamic`, any consumer accessing `.text` or `.edited` would crash with `NoSuchMethodError` on the wrong type.

## Changes

- **`AlarmComment.fromJson`** — calls `_parseComment()` to normalize `comment` into `AlarmCommentJsonNode`
- **`AlarmComment.toJson`** — serializes `AlarmCommentJsonNode` back to a `Map` via `.toJson()`
- **`_parseComment`** static method — handles `Map` → `AlarmCommentJsonNode.fromJson()`, `String` → wraps in `AlarmCommentJsonNode(text: ...)`, other → pass-through

## Test plan

- [ ] Deserialize an alarm comment with `comment` as a JSON object (`{"text": "hello"}`) — produces `AlarmCommentJsonNode`
- [ ] Deserialize an alarm comment with `comment` as a raw string (`"hello"`) — produces `AlarmCommentJsonNode` with `text: "hello"`
- [ ] Serialize an `AlarmComment` with `AlarmCommentJsonNode` comment — produces correct JSON map
- [ ] Post and update alarm comments via `AlarmService` — round-trips correctly