### PR TITLE
fix: sort alarms by subType (4.2.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.1
+- Fixed `AlarmType.fromJson` cast error when filtering alarms by type
+
 ## 4.2.0
 - Added `ImageService` for managing image uploads
 - Fixed `AlarmComment.comment` deserialization into `AlarmCommentJsonNode`

--- a/lib/src/model/entity_subtype/alarm_type.dart
+++ b/lib/src/model/entity_subtype/alarm_type.dart
@@ -2,7 +2,15 @@ import 'package:thingsboard_client/src/model/entity_subtype/entity_sub_type.dart
 
 class AlarmType extends EntitySubType {
   AlarmType(super.entityType, super.tenantId, super.type);
+
   @override
-  factory AlarmType.fromJson(Map<String, dynamic> json) =>
-      EntitySubType.fromJson(json) as AlarmType;
+  factory AlarmType.fromJson(Map<String, dynamic> json) {
+    final entitySubType = EntitySubType.fromJson(json);
+
+    return AlarmType(
+      entitySubType.entityType,
+      entitySubType.tenantId,
+      entitySubType.type,
+    );
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: thingsboard_client
 description: Dart implementation of ThingsBoard API client. Provides model objects and services to communicate with ThingsBoard platform using RESTful APIs and WebSocket protocol.
-version: 4.2.0
+version: 4.2.1
 homepage: https://thingsboard.io
 repository: https://github.com/thingsboard/dart_thingsboard_client.git
 issue_tracker: https://github.com/thingsboard/dart_thingsboard_client/issues


### PR DESCRIPTION
Fix sort alarms by subType (issue [#46](https://github.com/thingsboard/dart_thingsboard_pe_client/issues/46)).